### PR TITLE
Fetch Terraform Modules from a TFC/TFE Organization

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,5 +18,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
+      - name: Run Ruff
+        run: ruff check .
+      - name: Run Black check
+        run: black --check .
       - name: Run unit tests
         run: pytest -q --cov=src --cov-report=term-missing --cov-fail-under=80

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist
 terragenai.egg-info/
 .coverage
 htmlcov
+.ruff_cache
+src/_version.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,6 @@ python -m src.main
 
 Optional environment variables:
 
-- `TERRAGENAI_API_URL` (override backend URL)
 - `TERRAGENAI_CONFIG_FILE` (override config file location)
 - `TERRAGENAI_HISTORY_FILE` (override chat history file location)
 - `TERRAGENAI_HOME` (override app config/state base directory)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,16 @@ authors = [
 dependencies = [
   "typer>=0.9.0",
   "rich>=13.0.0",
-  "requests>=2.31.0"
+  "requests>=2.31.0",
+  "python-hcl2>=4.3.0"
 ]
 
 [project.optional-dependencies]
 dev = [
+  "black>=24.0.0",
   "pytest>=8.0.0",
-  "pytest-cov>=5.0.0"
+  "pytest-cov>=5.0.0",
+  "ruff>=0.6.0"
 ]
 
 [project.urls]
@@ -41,3 +44,19 @@ include = ["src*"]
 [tool.setuptools_scm]
 version_file = "src/_version.py"
 tag_regex = "^v(?P<version>\\d+\\.\\d+\\.\\d+)$"
+
+[tool.black]
+line-length = 88
+target-version = ["py39"]
+extend-exclude = '''
+^/src/_version\.py$
+'''
+
+[tool.ruff]
+line-length = 88
+target-version = "py39"
+extend-exclude = ["src/_version.py"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+ignore = ["E501"]

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@ terragenai --configure
 ```
 
 `--configure` saves settings to your OS-specific user config directory.
+It prompts for Terraform-related settings (`TF_ORG`, `TF_REGISTRY_DOMAIN`, `TF_API_TOKEN`, `GIT_CLONE_TOKEN`).
 
 Overrides:
 - `TERRAGENAI_HOME` to place both files in a single custom directory.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,4 @@
 from importlib.metadata import PackageNotFoundError, version
-from pathlib import Path
-import tomllib
 
 __all__ = ["__version__"]
 

--- a/src/client.py
+++ b/src/client.py
@@ -1,31 +1,17 @@
-import os
-
-import requests
-
-from .config import load_config
-
-DEFAULT_API_URL = "http://your-rag-service/chat"
-
-
-def get_api_url() -> str:
-    env_api_url = os.getenv("TERRAGENAI_API_URL")
-    if env_api_url:
-        return env_api_url
-
-    config_api_url = load_config().get("api_url")
-    if config_api_url:
-        return config_api_url
-
-    return DEFAULT_API_URL
-
-
 def send_message(history: list[dict]) -> str:
-    api_url = get_api_url()
+    user_prompt = ""
+    for message in reversed(history):
+        if message.get("role") == "user":
+            user_prompt = message.get("content", "")
+            break
 
-    if api_url == DEFAULT_API_URL:
-        return "Test response: run with --configure (or set TERRAGENAI_API_URL) to call your backend."
-
-    response = requests.post(api_url, json={"messages": history}, timeout=30)
-    response.raise_for_status()
-    data = response.json()
-    return data.get("response", str(data))
+    return (
+        "Generated starter Terraform (general resource blocks):\n\n"
+        "```hcl\n"
+        'resource "aws_instance" "example" {\n'
+        '  ami           = "ami-0123456789abcdef0"\n'
+        '  instance_type = "t3.micro"\n'
+        "}\n"
+        "```\n\n"
+        f"Input interpreted: {user_prompt or '(none)'}"
+    )

--- a/src/main.py
+++ b/src/main.py
@@ -1,13 +1,23 @@
 import argparse
 import sys
+
 from rich import print
 
 from . import __version__
 from .client import send_message
 from .config import get_config_file, load_config, save_config
 from .memory import add_message, load_history
+from .services.registry.base import ModuleRegistryService
+
 
 def chat() -> None:
+    registry_service = get_registry_service()
+    if not registry_service.validate_catalog():
+        print(
+            "[bold red]Registry module catalog not found. Run terragenai --sync first.[/bold red]"
+        )
+        return
+
     history = load_history()
     print("[bold green]TerragenAI Chat started. Type 'exit' to quit.[/bold green]")
 
@@ -25,14 +35,51 @@ def chat() -> None:
 
 def configure() -> None:
     current = load_config()
-    existing_api_url = current.get("api_url", "")
-    prompt = f"Enter API URL [{existing_api_url or 'http://localhost:8000/chat'}]: "
-    api_url = input(prompt).strip() or existing_api_url or "http://localhost:8000/chat"
-    config = {"api_url": api_url}
+    tf_org = input(
+        f"Enter TF_ORG [{current.get('TF_ORG', '')}]: "
+    ).strip() or current.get("TF_ORG", "")
+    tf_registry_domain = (
+        input(
+            "Enter TF_REGISTRY_DOMAIN "
+            f"[{current.get('TF_REGISTRY_DOMAIN') or 'app.terraform.io'}]: "
+        ).strip()
+        or current.get("TF_REGISTRY_DOMAIN")
+        or "app.terraform.io"
+    )
+    tf_api_token = input(
+        f"Enter TF_API_TOKEN [{current.get('TF_API_TOKEN', '')}]: "
+    ).strip() or current.get("TF_API_TOKEN", "")
+    git_clone_token = input(
+        f"Enter GIT_CLONE_TOKEN [{current.get('GIT_CLONE_TOKEN', '')}]: "
+    ).strip() or current.get("GIT_CLONE_TOKEN", "")
+    config = {
+        "TF_ORG": tf_org,
+        "TF_REGISTRY_DOMAIN": tf_registry_domain,
+        "TF_API_TOKEN": tf_api_token,
+        "GIT_CLONE_TOKEN": git_clone_token,
+    }
     save_config(config)
     print("[bold green]Saved configuration.[/bold green]")
-    print(f"API URL: {api_url}")
+    print(f"TF_ORG: {tf_org or '(not set)'}")
+    print(f"TF_REGISTRY_DOMAIN: {tf_registry_domain}")
+    print(f"TF_API_TOKEN: {'(set)' if tf_api_token else '(not set)'}")
+    print(f"GIT_CLONE_TOKEN: {'(set)' if git_clone_token else '(not set)'}")
     print(f"Config file: {get_config_file()}")
+
+
+registry_service = None
+
+
+def get_registry_service():
+    global registry_service
+    if registry_service is None:
+        registry_service = ModuleRegistryService()
+    return registry_service
+
+
+def sync_registry_modules():
+    registry_service = get_registry_service()
+    registry_service.build_catalog()
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -40,12 +87,24 @@ def build_parser() -> argparse.ArgumentParser:
         prog="terragenai",
         description="Simple Terragen AI chat CLI.",
     )
-    parser.add_argument("-v", "--version", action="store_true", help="Show version and exit.")
-    parser.add_argument("--configure", action="store_true", help="Configure CLI settings.")
+    parser.add_argument(
+        "-v", "--version", action="store_true", help="Show version and exit."
+    )
+    parser.add_argument(
+        "--configure", action="store_true", help="Configure CLI settings."
+    )
+    parser.add_argument(
+        "--sync",
+        "--sync-registry-modules",
+        dest="sync_registry_modules",
+        action="store_true",
+        help="Sync the latest modules from your Terraform Cloud/Enterprise private registry.",
+    )
     return parser
 
 
 def run() -> None:
+
     if len(sys.argv) == 1:
         chat()
         return
@@ -57,6 +116,10 @@ def run() -> None:
 
     if args.configure:
         configure()
+        return
+
+    if args.sync_registry_modules:
+        sync_registry_modules()
         return
 
     chat()

--- a/src/models/module_registry.py
+++ b/src/models/module_registry.py
@@ -1,0 +1,41 @@
+from ..config import load_config
+
+
+class ModuleRegistry:
+
+    def __init__(self):
+
+        config = load_config()
+
+        # Pulled directly from configuration
+        self.TF_ORG = config.get("TF_ORG", "").strip()
+        self.TF_REGISTRY_DOMAIN = config.get(
+            "TF_REGISTRY_DOMAIN", "app.terraform.io"
+        ).strip()
+        self.TF_API_TOKEN = config.get("TF_API_TOKEN", "").strip()
+        self.GIT_CLONE_TOKEN = config.get("GIT_CLONE_TOKEN", "").strip()
+
+        # Generated from configuration
+        self.IS_TFE = self.TF_REGISTRY_DOMAIN != "app.terraform.io"
+        self.TF_BASE_URL = f"https://{self.TF_REGISTRY_DOMAIN}/api/v2"
+        self.TF_REGISTRY_MODULES_URL = (
+            f"{self.TF_BASE_URL}/organizations/{self.TF_ORG}/registry-modules"
+        )
+        self.TF_HEADERS = {
+            "Authorization": f"Bearer {self.TF_API_TOKEN}",
+            "Content-Type": "application/vnd.api+json",
+        }
+
+        self._validate()
+
+    def _validate(self) -> None:
+        # TODO
+        missing = []
+        if not self.TF_ORG:
+            missing.append("TF_ORG")
+        if not self.TF_API_TOKEN:
+            missing.append("TF_API_TOKEN")
+        if missing:
+            raise ValueError(
+                f"Missing required config: {', '.join(missing)}. Run `terragenai --configure`."
+            )

--- a/src/services/registry/base.py
+++ b/src/services/registry/base.py
@@ -1,0 +1,186 @@
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Dict, List
+
+import hcl2
+import requests
+
+from ...models.module_registry import ModuleRegistry
+from ...paths import get_config_dir
+
+# TODO: Refactor
+
+
+class ModuleRegistryService:
+    def __init__(self):
+        self.registry = ModuleRegistry()
+        print(self.registry.TF_ORG)
+
+        base_dir = os.path.join(str(get_config_dir()), self.registry.TF_ORG)
+        os.makedirs(base_dir, exist_ok=True)
+        self.repo_dir = os.path.join(base_dir, "registry-repos")
+        self.catalog_dir = os.path.join(base_dir, "catalog")
+        self.catalog_path = os.path.join(self.catalog_dir, "modules.json")
+
+    # ------------------------------
+    # Module Registry helpers
+    # ------------------------------
+    def _http_get(self, url: str) -> Dict:
+        resp = requests.get(url, headers=self.registry.TF_HEADERS)
+        resp.raise_for_status()
+        return resp.json()
+
+    def _list_registry_modules(
+        self,
+    ) -> List[Dict]:
+        url = self.registry.TF_REGISTRY_MODULES_URL
+        modules = []
+
+        while url:
+            data = self._http_get(url)
+            modules.extend(data.get("data", []))
+            url = data.get("links", {}).get("next")
+
+        return modules
+
+    # ------------------------------
+    # Git helpers
+    # ------------------------------
+    def _git_clone_repo(self, repo_url: str):
+
+        if self.registry.GIT_CLONE_TOKEN:
+            repo_url = repo_url.replace(
+                "https://", f"https://{self.registry.GIT_CLONE_TOKEN}@"
+            )
+            repo_url = repo_url.replace(
+                "http://", f"http://{self.registry.GIT_CLONE_TOKEN}@"
+            )
+        subprocess.run(["git", "clone", "--quiet", repo_url, self.repo_dir], check=True)
+
+    def _git_checkout_tag(self, tag: str):
+        subprocess.run(
+            ["git", "checkout", "--quiet", tag], cwd=self.repo_dir, check=True
+        )
+
+    # ------------------------------
+    # Terraform parsing
+    # ------------------------------
+    def _parse_tf_variables(self) -> List[Dict]:
+        variables = []
+
+        for root, _, files in os.walk(self.repo_dir):
+            for file in files:
+                if not file.endswith(".tf"):
+                    continue
+
+                path = os.path.join(root, file)
+                try:
+                    with open(path, "r") as f:
+                        parsed = hcl2.load(f)
+                except Exception:
+                    continue
+
+                for block in parsed.get("variable", []):
+                    for name, attrs in block.items():
+                        variables.append(
+                            {
+                                "name": name,
+                                "type": attrs.get("type"),
+                                "description": attrs.get("description"),
+                                "default": attrs.get("default"),
+                                "required": "default" not in attrs,
+                            }
+                        )
+
+        # Deduplicate by name
+        unique = {v["name"]: v for v in variables}
+        return list(unique.values())
+
+    def _list_repo_files(self) -> List[str]:
+        files = []
+        for root, _, filenames in os.walk(self.repo_dir):
+            for f in filenames:
+                rel = os.path.relpath(os.path.join(root, f), self.repo_dir)
+                files.append(rel)
+        return files
+
+    # ------------------------------
+    # Main catalog builder
+    # ------------------------------
+    def build_catalog(self):
+        os.makedirs(self.catalog_dir, exist_ok=True)
+        catalog = {}
+
+        print(f"🔍 Fetching Terraform modules for org: {self.registry.TF_ORG}")
+        modules = self._list_registry_modules()
+
+        for mod in modules:
+            attrs = mod["attributes"]
+
+            name = attrs["name"]
+            namespace = attrs["namespace"]
+            provider = attrs["provider"]
+            vcs = attrs.get("vcs-repo")
+            versions = attrs.get("version-statuses", [])
+
+            if not vcs:
+                print(f"⚠ Skipping {name}: no VCS repo")
+                continue
+
+            repo_url = vcs["repository-http-url"]
+
+            print(f"\n📦 Module: {namespace}/{name}/{provider}")
+            print(f"   Repo: {repo_url}")
+
+            catalog.setdefault(repo_url, {})
+
+            try:
+                self._git_clone_repo(repo_url)
+            except Exception as e:
+                print(f"❌ Failed to clone {repo_url}: {e}")
+                continue
+
+            for v in versions:
+                tag = v.get("version")
+                if not tag.startswith("v"):
+                    tag = f"v{tag}"
+
+                try:
+                    self._git_checkout_tag(tag)
+                except Exception:
+                    print(f"⚠ Tag {tag} not found, skipping")
+                    continue
+
+                print(f"   → Processing version {tag}")
+
+                variables = self._parse_tf_variables()
+                files = self._list_repo_files()
+
+                catalog[repo_url][tag] = {
+                    "module_name": name,
+                    "namespace": namespace,
+                    "provider": provider,
+                    "source": f"{self.registry.TF_REGISTRY_DOMAIN}/{namespace}/{name}/{provider}",
+                    "variables": variables,
+                    "files": files,
+                    "vcs_available": True,
+                    "vcs_link": f"{repo_url}/tree/{tag}",
+                }
+
+            shutil.rmtree(self.repo_dir)
+
+        with open(self.catalog_path, "w") as f:
+            json.dump(catalog, f, indent=2)
+
+        print(f"\n✅ Catalog written to {self.catalog_path}")
+        print(f"📊 Total repos indexed: {len(catalog)}")
+
+    # ------------------------------
+    # Validate Catalog Exists
+    # ------------------------------
+    def validate_catalog(self):
+        p = Path(self.catalog_path)
+        return p.is_file() and p.stat().st_size > 0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,69 +1,21 @@
 from src import client
 
-class MockResponse:
-    def raise_for_status(self):
-        return None
 
-    def json(self):
-        return {"message": "ok"}
+def test_send_message_returns_starter_block_and_uses_latest_user_input():
+    history = [
+        {"role": "user", "content": "create ec2 instance"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "in us-west-2"},
+    ]
 
-def test_get_api_url_prefers_environment(monkeypatch):
-    monkeypatch.setenv("TERRAGENAI_API_URL", "https://env.example.com/chat")
-    monkeypatch.setattr(client, "load_config", lambda: {"api_url": "https://config.example.com/chat"})
+    response = client.send_message(history)
 
-    assert client.get_api_url() == "https://env.example.com/chat"
-
-
-def test_send_message_returns_stub_response_when_unconfigured(monkeypatch):
-    monkeypatch.delenv("TERRAGENAI_API_URL", raising=False)
-    monkeypatch.setattr(client, "load_config", lambda: {})
-
-    response = client.send_message([{"role": "user", "content": "hello"}])
-
-    assert "Test response" in response
+    assert "Generated starter Terraform" in response
+    assert 'resource "aws_instance" "example"' in response
+    assert "Input interpreted: in us-west-2" in response
 
 
-def test_send_message_calls_backend_when_configured(monkeypatch):
+def test_send_message_handles_empty_history():
+    response = client.send_message([])
 
-    called = {}
-
-    def fake_post(url, json, timeout):
-        called["url"] = url
-        called["json"] = json
-        called["timeout"] = timeout
-        return MockResponse()
-
-    monkeypatch.setenv("TERRAGENAI_API_URL", "https://api.example.com/chat")
-    monkeypatch.setattr(client.requests, "post", fake_post)
-
-    result = client.send_message([{"role": "user", "content": "hello"}])
-
-    assert result == "{'message': 'ok'}"
-    assert called["url"] == "https://api.example.com/chat"
-    assert called["json"] == {"messages": [{"role": "user", "content": "hello"}]}
-    assert called["timeout"] == 30
-
-
-def test_get_api_url_uses_config_when_env_missing(monkeypatch):
-    monkeypatch.delenv("TERRAGENAI_API_URL", raising=False)
-    monkeypatch.setattr(client, "load_config", lambda: {"api_url": "https://config.example.com/chat"})
-
-    assert client.get_api_url() == "https://config.example.com/chat"
-
-
-def test_get_api_url_falls_back_to_default(monkeypatch):
-    monkeypatch.delenv("TERRAGENAI_API_URL", raising=False)
-    monkeypatch.setattr(client, "load_config", lambda: {})
-
-    assert client.get_api_url() == client.DEFAULT_API_URL
-
-
-def test_send_message_returns_stringified_payload_when_response_key_missing(monkeypatch):
-
-
-    monkeypatch.setenv("TERRAGENAI_API_URL", "https://api.example.com/chat")
-    monkeypatch.setattr(client.requests, "post", lambda *_args, **_kwargs: MockResponse())
-
-    result = client.send_message([{"role": "user", "content": "hello"}])
-
-    assert result == "{'message': 'ok'}"
+    assert "Input interpreted: (none)" in response

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,7 +16,7 @@ def test_save_and_load_config_roundtrip(tmp_path, monkeypatch):
     config_file = tmp_path / ".terragenairc"
     monkeypatch.setenv("TERRAGENAI_CONFIG_FILE", str(config_file))
 
-    expected = {"api_url": "http://localhost:8000/chat"}
+    expected = {"TF_ORG": "my-org", "TF_REGISTRY_DOMAIN": "app.terraform.io"}
     save_config(expected)
 
     assert load_config() == expected

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,7 +16,9 @@ def test_build_parser_has_expected_flags():
 def test_run_starts_chat_when_no_args(monkeypatch):
     monkeypatch.setattr(main.sys, "argv", ["terragenai"])
     called = {"chat": 0}
-    monkeypatch.setattr(main, "chat", lambda: called.__setitem__("chat", called["chat"] + 1))
+    monkeypatch.setattr(
+        main, "chat", lambda: called.__setitem__("chat", called["chat"] + 1)
+    )
 
     main.run()
 
@@ -36,7 +38,11 @@ def test_run_version_flag_prints_version(monkeypatch):
 def test_run_configure_flag_calls_configure(monkeypatch):
     monkeypatch.setattr(main.sys, "argv", ["terragenai", "--configure"])
     called = {"configure": 0}
-    monkeypatch.setattr(main, "configure", lambda: called.__setitem__("configure", called["configure"] + 1))
+    monkeypatch.setattr(
+        main,
+        "configure",
+        lambda: called.__setitem__("configure", called["configure"] + 1),
+    )
 
     main.run()
 
@@ -49,9 +55,20 @@ def test_chat_round_trip(monkeypatch):
     output = []
 
     monkeypatch.setattr(builtins, "input", lambda _prompt="": next(prompts))
+    monkeypatch.setattr(
+        main,
+        "get_registry_service",
+        lambda: type("S", (), {"validate_catalog": lambda self: True})(),
+    )
     monkeypatch.setattr(main, "load_history", lambda: history_store)
     monkeypatch.setattr(main, "send_message", lambda _history: "hi there")
-    monkeypatch.setattr(main, "add_message", lambda history, role, content: history.append({"role": role, "content": content}))
+    monkeypatch.setattr(
+        main,
+        "add_message",
+        lambda history, role, content: history.append(
+            {"role": role, "content": content}
+        ),
+    )
     monkeypatch.setattr(main, "print", lambda value: output.append(value))
 
     main.chat()
@@ -75,5 +92,10 @@ def test_configure_uses_default_when_input_blank(monkeypatch):
 
     main.configure()
 
-    assert saved == {"api_url": "http://localhost:8000/chat"}
+    assert saved == {
+        "TF_ORG": "",
+        "TF_REGISTRY_DOMAIN": "app.terraform.io",
+        "TF_API_TOKEN": "",
+        "GIT_CLONE_TOKEN": "",
+    }
     assert any("Saved configuration" in str(line) for line in output)

--- a/tests/test_module_registry.py
+++ b/tests/test_module_registry.py
@@ -1,0 +1,59 @@
+import pytest
+
+from src.models import module_registry
+
+
+def test_module_registry_loads_config_and_computed_fields(monkeypatch):
+    monkeypatch.setattr(
+        module_registry,
+        "load_config",
+        lambda: {
+            "TF_ORG": "my-org",
+            "TF_REGISTRY_DOMAIN": "tfe.example.com",
+            "TF_API_TOKEN": "token-123",
+            "GIT_CLONE_TOKEN": "git-456",
+        },
+    )
+
+    registry = module_registry.ModuleRegistry()
+
+    assert registry.TF_ORG == "my-org"
+    assert registry.TF_REGISTRY_DOMAIN == "tfe.example.com"
+    assert registry.TF_API_TOKEN == "token-123"
+    assert registry.GIT_CLONE_TOKEN == "git-456"
+    assert registry.IS_TFE is True
+    assert registry.TF_BASE_URL == "https://tfe.example.com/api/v2"
+    assert (
+        registry.TF_REGISTRY_MODULES_URL
+        == "https://tfe.example.com/api/v2/organizations/my-org/registry-modules"
+    )
+    assert registry.TF_HEADERS["Authorization"] == "Bearer token-123"
+
+
+def test_module_registry_defaults_registry_domain(monkeypatch):
+    monkeypatch.setattr(
+        module_registry,
+        "load_config",
+        lambda: {"TF_ORG": "my-org", "TF_API_TOKEN": "token-123"},
+    )
+
+    registry = module_registry.ModuleRegistry()
+
+    assert registry.TF_REGISTRY_DOMAIN == "app.terraform.io"
+    assert registry.IS_TFE is False
+
+
+@pytest.mark.parametrize(
+    "cfg,missing_key",
+    [
+        ({"TF_API_TOKEN": "token-123"}, "TF_ORG"),
+        ({"TF_ORG": "my-org"}, "TF_API_TOKEN"),
+    ],
+)
+def test_module_registry_validate_missing_required(monkeypatch, cfg, missing_key):
+    monkeypatch.setattr(module_registry, "load_config", lambda: cfg)
+
+    with pytest.raises(ValueError) as exc:
+        module_registry.ModuleRegistry()
+
+    assert missing_key in str(exc.value)

--- a/tests/test_module_registry_service.py
+++ b/tests/test_module_registry_service.py
@@ -1,0 +1,128 @@
+import json
+
+from src.services.registry import base
+
+
+class FakeRegistry:
+    TF_ORG = "my-org"
+    TF_REGISTRY_DOMAIN = "app.terraform.io"
+    TF_API_TOKEN = "token-123"
+    GIT_CLONE_TOKEN = ""
+    TF_HEADERS = {"Authorization": "Bearer token-123"}
+    TF_REGISTRY_MODULES_URL = (
+        "https://app.terraform.io/api/v2/organizations/my-org/registry-modules"
+    )
+
+
+def _build_service(tmp_path, monkeypatch):
+    monkeypatch.setattr(base, "ModuleRegistry", lambda: FakeRegistry())
+    monkeypatch.setattr(base, "get_config_dir", lambda: tmp_path)
+    return base.ModuleRegistryService()
+
+
+def test_service_initializes_paths(tmp_path, monkeypatch):
+    service = _build_service(tmp_path, monkeypatch)
+
+    assert service.repo_dir == str(tmp_path / "my-org" / "registry-repos")
+    assert service.catalog_dir == str(tmp_path / "my-org" / "catalog")
+    assert service.catalog_path == str(tmp_path / "my-org" / "catalog" / "modules.json")
+
+
+def test_validate_catalog(tmp_path, monkeypatch):
+    service = _build_service(tmp_path, monkeypatch)
+
+    assert service.validate_catalog() is False
+
+    (tmp_path / "my-org" / "catalog").mkdir(parents=True, exist_ok=True)
+    with open(service.catalog_path, "w", encoding="utf-8") as f:
+        f.write("{}")
+
+    assert service.validate_catalog() is True
+
+
+def test_list_registry_modules_follows_pagination(tmp_path, monkeypatch):
+    service = _build_service(tmp_path, monkeypatch)
+    pages = [
+        {
+            "data": [{"id": "1"}],
+            "links": {"next": "https://example.com/page-2"},
+        },
+        {
+            "data": [{"id": "2"}],
+            "links": {"next": None},
+        },
+    ]
+    calls = {"count": 0}
+
+    def fake_get(_url):
+        idx = calls["count"]
+        calls["count"] += 1
+        return pages[idx]
+
+    monkeypatch.setattr(service, "_http_get", fake_get)
+
+    modules = service._list_registry_modules()
+
+    assert modules == [{"id": "1"}, {"id": "2"}]
+    assert calls["count"] == 2
+
+
+def test_git_clone_repo_uses_clone_token(tmp_path, monkeypatch):
+    class FakeRegistryWithToken(FakeRegistry):
+        GIT_CLONE_TOKEN = "git-token"
+
+    monkeypatch.setattr(base, "ModuleRegistry", lambda: FakeRegistryWithToken())
+    monkeypatch.setattr(base, "get_config_dir", lambda: tmp_path)
+    service = base.ModuleRegistryService()
+
+    called = {}
+
+    def fake_run(cmd, check):
+        called["cmd"] = cmd
+        called["check"] = check
+
+    monkeypatch.setattr(base.subprocess, "run", fake_run)
+    service._git_clone_repo("https://github.com/example/repo.git")
+
+    assert called["check"] is True
+    assert called["cmd"][0:3] == ["git", "clone", "--quiet"]
+    assert called["cmd"][3].startswith("https://git-token@github.com/")
+
+
+def test_build_catalog_writes_modules_json(tmp_path, monkeypatch):
+    service = _build_service(tmp_path, monkeypatch)
+
+    monkeypatch.setattr(
+        service,
+        "_list_registry_modules",
+        lambda: [
+            {
+                "attributes": {
+                    "name": "vpc",
+                    "namespace": "my-org",
+                    "provider": "aws",
+                    "vcs-repo": {
+                        "repository-http-url": "https://github.com/example/vpc.git"
+                    },
+                    "version-statuses": [{"version": "1.0.0"}],
+                }
+            }
+        ],
+    )
+    monkeypatch.setattr(service, "_git_clone_repo", lambda _repo_url: None)
+    monkeypatch.setattr(service, "_git_checkout_tag", lambda _tag: None)
+    monkeypatch.setattr(
+        service, "_parse_tf_variables", lambda: [{"name": "region", "required": True}]
+    )
+    monkeypatch.setattr(service, "_list_repo_files", lambda: ["main.tf"])
+    monkeypatch.setattr(base.shutil, "rmtree", lambda _path: None)
+
+    service.build_catalog()
+
+    with open(service.catalog_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    repo_key = "https://github.com/example/vpc.git"
+    assert repo_key in data
+    assert "v1.0.0" in data[repo_key]
+    assert data[repo_key]["v1.0.0"]["source"] == "app.terraform.io/my-org/vpc/aws"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -37,7 +37,9 @@ def test_get_state_dir_uses_xdg_state_on_posix(monkeypatch):
 def test_get_config_dir_uses_appdata_on_windows(monkeypatch):
     monkeypatch.delenv("TERRAGENAI_HOME", raising=False)
     monkeypatch.setattr(paths.sys, "platform", "win32")
-    fake_os = SimpleNamespace(name="nt", getenv=lambda key: {"APPDATA": "/tmp/appdata"}.get(key))
+    fake_os = SimpleNamespace(
+        name="nt", getenv=lambda key: {"APPDATA": "/tmp/appdata"}.get(key)
+    )
     monkeypatch.setattr(paths, "os", fake_os)
 
     assert paths.get_config_dir() == Path("/tmp/appdata/.terragenai")
@@ -46,7 +48,9 @@ def test_get_config_dir_uses_appdata_on_windows(monkeypatch):
 def test_get_state_dir_uses_localappdata_on_windows(monkeypatch):
     monkeypatch.delenv("TERRAGENAI_HOME", raising=False)
     monkeypatch.setattr(paths.sys, "platform", "win32")
-    fake_os = SimpleNamespace(name="nt", getenv=lambda key: {"LOCALAPPDATA": "/tmp/localappdata"}.get(key))
+    fake_os = SimpleNamespace(
+        name="nt", getenv=lambda key: {"LOCALAPPDATA": "/tmp/localappdata"}.get(key)
+    )
     monkeypatch.setattr(paths, "os", fake_os)
 
     assert paths.get_state_dir() == Path("/tmp/localappdata/.terragenai")
@@ -55,7 +59,9 @@ def test_get_state_dir_uses_localappdata_on_windows(monkeypatch):
 def test_get_config_dir_darwin(monkeypatch):
     monkeypatch.delenv("TERRAGENAI_HOME", raising=False)
     monkeypatch.setattr(paths.sys, "platform", "darwin")
-    monkeypatch.setattr(paths.Path, "home", classmethod(lambda _cls: Path("/Users/test")))
+    monkeypatch.setattr(
+        paths.Path, "home", classmethod(lambda _cls: Path("/Users/test"))
+    )
 
     assert paths.get_config_dir() == Path("/Users/test/.terragenai")
 
@@ -63,9 +69,13 @@ def test_get_config_dir_darwin(monkeypatch):
 def test_get_state_dir_darwin(monkeypatch):
     monkeypatch.delenv("TERRAGENAI_HOME", raising=False)
     monkeypatch.setattr(paths.sys, "platform", "darwin")
-    monkeypatch.setattr(paths.Path, "home", classmethod(lambda _cls: Path("/Users/test")))
+    monkeypatch.setattr(
+        paths.Path, "home", classmethod(lambda _cls: Path("/Users/test"))
+    )
 
-    assert paths.get_state_dir() == Path("/Users/test/Library/Application Support/.terragenai")
+    assert paths.get_state_dir() == Path(
+        "/Users/test/Library/Application Support/.terragenai"
+    )
 
 
 def test_ensure_dir_creates_directory(tmp_path):

--- a/tests/test_version_module.py
+++ b/tests/test_version_module.py
@@ -1,0 +1,10 @@
+from src import _version
+
+
+def test_generated_version_module_exports_values():
+    assert isinstance(_version.__version__, str)
+    assert _version.__version__ == _version.version
+    assert isinstance(_version.__version_tuple__, tuple)
+    assert _version.__version_tuple__ == _version.version_tuple
+    assert isinstance(_version.__commit_id__, str)
+    assert _version.__commit_id__ == _version.commit_id


### PR DESCRIPTION
### [Fetch Terraform Modules from a TFC/TFE Organization](#6 ) 
#6 
- This PR introduces registry sync support and code quality checks in CI.

### What’s Included

- Implemented a working registry sync flow to fetch private registry modules from a Terraform Cloud/Terraform Enterprise organization.
  - New CLI command: `terragenai --sync`

- Added linting and formatting checks to CI.
  - `ruff check .`
  - `black --check .`
  - Updated project/dev tooling configuration in `pyproject.toml` for ruff and black.

### Why

- Enables pulling organization-approved registry modules for local catalog use.
- Improves consistency and maintainability by enforcing formatting/linting on every CI run.

### How to Test

- Configure required Terraform settings:
  - `terragenai --configure`
- Run module sync:
  - `terragenai --sync`
- Run local quality checks:
  - `python -m ruff check .`
  - `python -m black --check .`
- Run unit tests locally:
  - `python -m pytest -q`
  - `python -m pytest -q --cov=src --cov-report=term-missing --cov-fail-under=80 `  

### TODO

- Refactor `ModuleRegistryService`
- Update `ModuleRegistry._validate`